### PR TITLE
 Implemented feature: Allow registration of custom listeners for endpoints

### DIFF
--- a/server/headers.go
+++ b/server/headers.go
@@ -42,7 +42,7 @@ func replaceInVals(key, old, new string) copyOption {
 		opts.replacers = append(
 			opts.replacers,
 			func(k string, vv []string) (string, []string, bool) {
-				if strings.ToLower(key) == strings.ToLower(k) {
+				if strings.EqualFold(k, key) {
 					vv2 := make([]string, 0, len(vv))
 					for _, v := range vv {
 						vv2 = append(


### PR DESCRIPTION
Added support for custom listeners, the newGoApiBoot function takes a **map[string]func(http.ResponseWriter, *http.Request* )** for registering the endpoints to respective handlers